### PR TITLE
add unified topic type system

### DIFF
--- a/src/main/java/org/texttechnologylab/annotation/TopicValueBase.java
+++ b/src/main/java/org/texttechnologylab/annotation/TopicValueBase.java
@@ -1,0 +1,166 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Thu Apr 03 09:36:12 CEST 2025 */
+
+package org.texttechnologylab.annotation;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import org.apache.uima.jcas.cas.FSArray;
+import org.apache.uima.jcas.cas.AnnotationBase;
+
+
+/** 
+ * Updated by JCasGen Thu Apr 03 09:36:12 CEST 2025
+ * XML source: /home/staff_homes/verma/Documents/projects/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class TopicValueBase extends AnnotationBase {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.TopicValueBase";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(TopicValueBase.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_value = "value";
+  public final static String _FeatName_words = "words";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_value = TypeSystemImpl.createCallSite(TopicValueBase.class, "value");
+  private final static MethodHandle _FH_value = _FC_value.dynamicInvoker();
+  private final static CallSite _FC_words = TypeSystemImpl.createCallSite(TopicValueBase.class, "words");
+  private final static MethodHandle _FH_words = _FC_words.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected TopicValueBase() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public TopicValueBase(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public TopicValueBase(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: value
+
+  /** getter for value - gets Topic Label
+   * @generated
+   * @return value of the feature 
+   */
+  public String getValue() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_value));
+  }
+    
+  /** setter for value - sets Topic Label 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setValue(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_value), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: words
+
+  /** getter for words - gets Set of words with probabilities
+   * @generated
+   * @return value of the feature 
+   */
+  @SuppressWarnings("unchecked")
+  public FSArray<TopicWord> getWords() { 
+    return (FSArray<TopicWord>)(_getFeatureValueNc(wrapGetIntCatchException(_FH_words)));
+  }
+    
+  /** setter for words - sets Set of words with probabilities 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setWords(FSArray<TopicWord> v) {
+    _setFeatureValueNcWj(wrapGetIntCatchException(_FH_words), v);
+  }    
+    
+    
+  /** indexed getter for words - gets an indexed value - Set of words with probabilities
+   * @generated
+   * @param i index in the array to get
+   * @return value of the element at index i 
+   */
+  @SuppressWarnings("unchecked")
+  public TopicWord getWords(int i) {
+     return (TopicWord)(((FSArray<TopicWord>)(_getFeatureValueNc(wrapGetIntCatchException(_FH_words)))).get(i));
+  } 
+
+  /** indexed setter for words - sets an indexed value - Set of words with probabilities
+   * @generated
+   * @param i index in the array to set
+   * @param v value to set into the array 
+   */
+  @SuppressWarnings("unchecked")
+    public void setWords(int i, TopicWord v) {
+    ((FSArray<TopicWord>)(_getFeatureValueNc(wrapGetIntCatchException(_FH_words)))).set(i, v);
+  }  
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/TopicValueBaseWithScore.java
+++ b/src/main/java/org/texttechnologylab/annotation/TopicValueBaseWithScore.java
@@ -1,0 +1,119 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Thu Apr 03 09:36:12 CEST 2025 */
+
+package org.texttechnologylab.annotation;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Thu Apr 03 09:36:12 CEST 2025
+ * XML source: /home/staff_homes/verma/Documents/projects/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class TopicValueBaseWithScore extends TopicValueBase {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.TopicValueBaseWithScore";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(TopicValueBaseWithScore.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_score = "score";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_score = TypeSystemImpl.createCallSite(TopicValueBaseWithScore.class, "score");
+  private final static MethodHandle _FH_score = _FC_score.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected TopicValueBaseWithScore() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public TopicValueBaseWithScore(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public TopicValueBaseWithScore(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: score
+
+  /** getter for score - gets Probability of the topic label
+   * @generated
+   * @return value of the feature 
+   */
+  public double getScore() { 
+    return _getDoubleValueNc(wrapGetIntCatchException(_FH_score));
+  }
+    
+  /** setter for score - sets Probability of the topic label 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setScore(double v) {
+    _setDoubleValueNfc(wrapGetIntCatchException(_FH_score), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/TopicWord.java
+++ b/src/main/java/org/texttechnologylab/annotation/TopicWord.java
@@ -1,0 +1,180 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Thu Apr 03 09:36:12 CEST 2025 */
+
+package org.texttechnologylab.annotation;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+/** Word that contributes to a topic in unsupervised models
+ * Updated by JCasGen Thu Apr 03 09:36:12 CEST 2025
+ * XML source: /home/staff_homes/verma/Documents/projects/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class TopicWord extends Annotation {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.TopicWord";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(TopicWord.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_word = "word";
+  public final static String _FeatName_probability = "probability";
+  public final static String _FeatName_topic = "topic";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_word = TypeSystemImpl.createCallSite(TopicWord.class, "word");
+  private final static MethodHandle _FH_word = _FC_word.dynamicInvoker();
+  private final static CallSite _FC_probability = TypeSystemImpl.createCallSite(TopicWord.class, "probability");
+  private final static MethodHandle _FH_probability = _FC_probability.dynamicInvoker();
+  private final static CallSite _FC_topic = TypeSystemImpl.createCallSite(TopicWord.class, "topic");
+  private final static MethodHandle _FH_topic = _FC_topic.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected TopicWord() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public TopicWord(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public TopicWord(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public TopicWord(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: word
+
+  /** getter for word - gets The word associated with a topic
+   * @generated
+   * @return value of the feature 
+   */
+  public String getWord() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_word));
+  }
+    
+  /** setter for word - sets The word associated with a topic 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setWord(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_word), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: probability
+
+  /** getter for probability - gets Probability of the word belonging to a topic
+   * @generated
+   * @return value of the feature 
+   */
+  public double getProbability() { 
+    return _getDoubleValueNc(wrapGetIntCatchException(_FH_probability));
+  }
+    
+  /** setter for probability - sets Probability of the word belonging to a topic 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setProbability(double v) {
+    _setDoubleValueNfc(wrapGetIntCatchException(_FH_probability), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: topic
+
+  /** getter for topic - gets The topic associated with the word
+   * @generated
+   * @return value of the feature 
+   */
+  public TopicValueBase getTopic() { 
+    return (TopicValueBase)(_getFeatureValueNc(wrapGetIntCatchException(_FH_topic)));
+  }
+    
+  /** setter for topic - sets The topic associated with the word 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setTopic(TopicValueBase v) {
+    _setFeatureValueNcWj(wrapGetIntCatchException(_FH_topic), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/UnifiedTopic.java
+++ b/src/main/java/org/texttechnologylab/annotation/UnifiedTopic.java
@@ -1,0 +1,179 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Thu Apr 03 09:36:12 CEST 2025 */
+
+package org.texttechnologylab.annotation;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import org.apache.uima.jcas.cas.FSArray;
+import org.texttechnologylab.annotation.model.MetaData;
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+/** 
+ * Updated by JCasGen Thu Apr 03 09:36:12 CEST 2025
+ * XML source: /home/staff_homes/verma/Documents/projects/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class UnifiedTopic extends Annotation {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.UnifiedTopic";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(UnifiedTopic.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_Topics = "Topics";
+  public final static String _FeatName_metadata = "metadata";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_Topics = TypeSystemImpl.createCallSite(UnifiedTopic.class, "Topics");
+  private final static MethodHandle _FH_Topics = _FC_Topics.dynamicInvoker();
+  private final static CallSite _FC_metadata = TypeSystemImpl.createCallSite(UnifiedTopic.class, "metadata");
+  private final static MethodHandle _FH_metadata = _FC_metadata.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected UnifiedTopic() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public UnifiedTopic(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public UnifiedTopic(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public UnifiedTopic(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: Topics
+
+  /** getter for Topics - gets Set of topic labels
+   * @generated
+   * @return value of the feature 
+   */
+  @SuppressWarnings("unchecked")
+  public FSArray<TopicValueBase> getTopics() { 
+    return (FSArray<TopicValueBase>)(_getFeatureValueNc(wrapGetIntCatchException(_FH_Topics)));
+  }
+    
+  /** setter for Topics - sets Set of topic labels 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setTopics(FSArray<TopicValueBase> v) {
+    _setFeatureValueNcWj(wrapGetIntCatchException(_FH_Topics), v);
+  }    
+    
+    
+  /** indexed getter for Topics - gets an indexed value - Set of topic labels
+   * @generated
+   * @param i index in the array to get
+   * @return value of the element at index i 
+   */
+  @SuppressWarnings("unchecked")
+  public TopicValueBase getTopics(int i) {
+     return (TopicValueBase)(((FSArray<TopicValueBase>)(_getFeatureValueNc(wrapGetIntCatchException(_FH_Topics)))).get(i));
+  } 
+
+  /** indexed setter for Topics - sets an indexed value - Set of topic labels
+   * @generated
+   * @param i index in the array to set
+   * @param v value to set into the array 
+   */
+  @SuppressWarnings("unchecked")
+    public void setTopics(int i, TopicValueBase v) {
+    ((FSArray<TopicValueBase>)(_getFeatureValueNc(wrapGetIntCatchException(_FH_Topics)))).set(i, v);
+  }  
+   
+    
+  //*--------------*
+  //* Feature: metadata
+
+  /** getter for metadata - gets Metadata for the model and data
+   * @generated
+   * @return value of the feature 
+   */
+  public MetaData getMetadata() { 
+    return (MetaData)(_getFeatureValueNc(wrapGetIntCatchException(_FH_metadata)));
+  }
+    
+  /** setter for metadata - sets Metadata for the model and data 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setMetadata(MetaData v) {
+    _setFeatureValueNcWj(wrapGetIntCatchException(_FH_metadata), v);
+  }    
+    
+  }
+
+    

--- a/src/main/resources/desc/type/TypeSystemUnifiedTopic.xml
+++ b/src/main/resources/desc/type/TypeSystemUnifiedTopic.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <name>UnifiedTopic</name>
+    <description>Type system supporting all topic models (supervised and unsupervised)</description>
+    <version>1.0</version>
+    <vendor/>
+    <types>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.UnifiedTopic</name>
+            <description/>
+            <supertypeName>uima.tcas.Annotation</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>Topics</name>
+                    <description>Set of topic labels</description>
+                    <rangeTypeName>uima.cas.FSArray</rangeTypeName>
+                    <elementType>org.texttechnologylab.annotation.TopicValueBase</elementType>
+                </featureDescription>
+                <featureDescription>
+                    <name>metadata</name>
+                    <description>Metadata for the model and data</description>
+                    <rangeTypeName>org.texttechnologylab.annotation.model.MetaData</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.TopicValueBase</name>
+            <description/>
+            <supertypeName>uima.cas.AnnotationBase</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>value</name>
+                    <description>Topic Label</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>words</name>
+                    <description>Set of words with probabilities</description>
+                    <rangeTypeName>uima.cas.FSArray</rangeTypeName>
+                    <elementType>org.texttechnologylab.annotation.TopicWord</elementType>
+                </featureDescription>
+            </features>
+        </typeDescription>
+
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.TopicValueBaseWithScore</name>
+            <description/>
+            <supertypeName>org.texttechnologylab.annotation.TopicValueBase</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>score</name>
+                    <description>Probability of the topic label</description>
+                    <rangeTypeName>uima.cas.Double</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.TopicWord</name>
+            <description>Word that contributes to a topic in unsupervised models</description>
+            <supertypeName>uima.tcas.Annotation</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>word</name>
+                    <description>The word associated with a topic</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>probability</name>
+                    <description>Probability of the word belonging to a topic</description>
+                    <rangeTypeName>uima.cas.Double</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>topic</name>
+                    <description>The topic associated with the word</description>
+                    <rangeTypeName>org.texttechnologylab.annotation.TopicValueBase</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.MetaData</name>
+            <description/>
+            <supertypeName>uima.tcas.Annotation</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>Lang</name>
+                    <description>Language of the method or the Model</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>Source</name>
+                    <description>Link of the used resource</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+            </features>
+
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.model.MetaData</name>
+            <description/>
+            <supertypeName>org.texttechnologylab.annotation.MetaData</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>ModelVersion</name>
+                    <description>Version of the Model</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>ModelName</name>
+                    <description>Name of the Model</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+            </features>
+
+        </typeDescription>
+
+    </types>
+</typeSystemDescription>


### PR DESCRIPTION
This PR adds a type system called `UnifiedTopic`. It can be used for annotating results from different topic models such as LDA, topic classification models, BERTopic and LLM based topic generation.

For models that generate topic as probability distribution over words, `TopicWord` can be used to annotate words and their probabilities.

For models that classify predefined topic classes, `TopicValueBaseWithScore` can be used to assign probabilities to all the topic classes.

Finally for the models that only generate topic labels without probabilities such as LLM based topic models, `TopicValueBase` can be used.