### PR TITLE
New Type System for ABBYY FineReader OCR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.texttechnologylab.annotation</groupId>
     <artifactId>typesystem</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6-alpha</version>
 
     <licenses>
         <license>
@@ -103,15 +103,15 @@
                         src/main/java/
                     </outputDirectory>
                 </configuration>
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        &lt;!&ndash;call it in the generate-source phase &ndash;&gt;-->
-<!--                        <phase>generate-sources</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>generate</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
+                <executions>
+                    <execution>
+                        <!--call it in the generate-source phase -->
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Block.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Block.java
@@ -1,0 +1,155 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Block extends StructuralElement {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Block";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Block.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_blockType = "blockType";
+  public final static String _FeatName_blockName = "blockName";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_blockType = TypeSystemImpl.createCallSite(Block.class, "blockType");
+  private final static MethodHandle _FH_blockType = _FC_blockType.dynamicInvoker();
+  private final static CallSite _FC_blockName = TypeSystemImpl.createCallSite(Block.class, "blockName");
+  private final static MethodHandle _FH_blockName = _FC_blockName.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Block() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Block(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Block(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Block(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: blockType
+
+  /** getter for blockType - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getBlockType() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_blockType));
+  }
+    
+  /** setter for blockType - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setBlockType(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_blockType), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: blockName
+
+  /** getter for blockName - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getBlockName() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_blockName));
+  }
+    
+  /** setter for blockName - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setBlockName(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_blockName), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Document.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Document.java
@@ -1,0 +1,251 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Document extends de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Document {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Document";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Document.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_documentName = "documentName";
+  public final static String _FeatName_version = "version";
+  public final static String _FeatName_producer = "producer";
+  public final static String _FeatName_pagesCount = "pagesCount";
+  public final static String _FeatName_mainLanguage = "mainLanguage";
+  public final static String _FeatName_languages = "languages";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_documentName = TypeSystemImpl.createCallSite(Document.class, "documentName");
+  private final static MethodHandle _FH_documentName = _FC_documentName.dynamicInvoker();
+  private final static CallSite _FC_version = TypeSystemImpl.createCallSite(Document.class, "version");
+  private final static MethodHandle _FH_version = _FC_version.dynamicInvoker();
+  private final static CallSite _FC_producer = TypeSystemImpl.createCallSite(Document.class, "producer");
+  private final static MethodHandle _FH_producer = _FC_producer.dynamicInvoker();
+  private final static CallSite _FC_pagesCount = TypeSystemImpl.createCallSite(Document.class, "pagesCount");
+  private final static MethodHandle _FH_pagesCount = _FC_pagesCount.dynamicInvoker();
+  private final static CallSite _FC_mainLanguage = TypeSystemImpl.createCallSite(Document.class, "mainLanguage");
+  private final static MethodHandle _FH_mainLanguage = _FC_mainLanguage.dynamicInvoker();
+  private final static CallSite _FC_languages = TypeSystemImpl.createCallSite(Document.class, "languages");
+  private final static MethodHandle _FH_languages = _FC_languages.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Document() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Document(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Document(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Document(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: documentName
+
+  /** getter for documentName - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getDocumentName() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_documentName));
+  }
+    
+  /** setter for documentName - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setDocumentName(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_documentName), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: version
+
+  /** getter for version - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getVersion() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_version));
+  }
+    
+  /** setter for version - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setVersion(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_version), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: producer
+
+  /** getter for producer - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getProducer() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_producer));
+  }
+    
+  /** setter for producer - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setProducer(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_producer), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: pagesCount
+
+  /** getter for pagesCount - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getPagesCount() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_pagesCount));
+  }
+    
+  /** setter for pagesCount - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setPagesCount(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_pagesCount), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: mainLanguage
+
+  /** getter for mainLanguage - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getMainLanguage() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_mainLanguage));
+  }
+    
+  /** setter for mainLanguage - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setMainLanguage(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_mainLanguage), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: languages
+
+  /** getter for languages - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getLanguages() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_languages));
+  }
+    
+  /** setter for languages - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setLanguages(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_languages), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Format.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Format.java
@@ -1,0 +1,348 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Format extends Annotation {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Format";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Format.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_lang = "lang";
+  public final static String _FeatName_ff = "ff";
+  public final static String _FeatName_fs = "fs";
+  public final static String _FeatName_bold = "bold";
+  public final static String _FeatName_italic = "italic";
+  public final static String _FeatName_subscript = "subscript";
+  public final static String _FeatName_superscript = "superscript";
+  public final static String _FeatName_smallcaps = "smallcaps";
+  public final static String _FeatName_underline = "underline";
+  public final static String _FeatName_strikeout = "strikeout";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_lang = TypeSystemImpl.createCallSite(Format.class, "lang");
+  private final static MethodHandle _FH_lang = _FC_lang.dynamicInvoker();
+  private final static CallSite _FC_ff = TypeSystemImpl.createCallSite(Format.class, "ff");
+  private final static MethodHandle _FH_ff = _FC_ff.dynamicInvoker();
+  private final static CallSite _FC_fs = TypeSystemImpl.createCallSite(Format.class, "fs");
+  private final static MethodHandle _FH_fs = _FC_fs.dynamicInvoker();
+  private final static CallSite _FC_bold = TypeSystemImpl.createCallSite(Format.class, "bold");
+  private final static MethodHandle _FH_bold = _FC_bold.dynamicInvoker();
+  private final static CallSite _FC_italic = TypeSystemImpl.createCallSite(Format.class, "italic");
+  private final static MethodHandle _FH_italic = _FC_italic.dynamicInvoker();
+  private final static CallSite _FC_subscript = TypeSystemImpl.createCallSite(Format.class, "subscript");
+  private final static MethodHandle _FH_subscript = _FC_subscript.dynamicInvoker();
+  private final static CallSite _FC_superscript = TypeSystemImpl.createCallSite(Format.class, "superscript");
+  private final static MethodHandle _FH_superscript = _FC_superscript.dynamicInvoker();
+  private final static CallSite _FC_smallcaps = TypeSystemImpl.createCallSite(Format.class, "smallcaps");
+  private final static MethodHandle _FH_smallcaps = _FC_smallcaps.dynamicInvoker();
+  private final static CallSite _FC_underline = TypeSystemImpl.createCallSite(Format.class, "underline");
+  private final static MethodHandle _FH_underline = _FC_underline.dynamicInvoker();
+  private final static CallSite _FC_strikeout = TypeSystemImpl.createCallSite(Format.class, "strikeout");
+  private final static MethodHandle _FH_strikeout = _FC_strikeout.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Format() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Format(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Format(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Format(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: lang
+
+  /** getter for lang - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getLang() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_lang));
+  }
+    
+  /** setter for lang - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setLang(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_lang), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: ff
+
+  /** getter for ff - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getFf() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_ff));
+  }
+    
+  /** setter for ff - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setFf(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_ff), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: fs
+
+  /** getter for fs - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public float getFs() { 
+    return _getFloatValueNc(wrapGetIntCatchException(_FH_fs));
+  }
+    
+  /** setter for fs - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setFs(float v) {
+    _setFloatValueNfc(wrapGetIntCatchException(_FH_fs), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: bold
+
+  /** getter for bold - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getBold() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_bold));
+  }
+    
+  /** setter for bold - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setBold(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_bold), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: italic
+
+  /** getter for italic - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getItalic() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_italic));
+  }
+    
+  /** setter for italic - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setItalic(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_italic), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: subscript
+
+  /** getter for subscript - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getSubscript() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_subscript));
+  }
+    
+  /** setter for subscript - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setSubscript(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_subscript), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: superscript
+
+  /** getter for superscript - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getSuperscript() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_superscript));
+  }
+    
+  /** setter for superscript - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setSuperscript(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_superscript), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: smallcaps
+
+  /** getter for smallcaps - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getSmallcaps() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_smallcaps));
+  }
+    
+  /** setter for smallcaps - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setSmallcaps(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_smallcaps), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: underline
+
+  /** getter for underline - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getUnderline() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_underline));
+  }
+    
+  /** setter for underline - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setUnderline(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_underline), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: strikeout
+
+  /** getter for strikeout - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getStrikeout() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_strikeout));
+  }
+    
+  /** setter for strikeout - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setStrikeout(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_strikeout), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Line.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Line.java
@@ -1,0 +1,155 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Line extends StructuralElement {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Line";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Line.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_baseline = "baseline";
+  public final static String _FeatName_format = "format";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_baseline = TypeSystemImpl.createCallSite(Line.class, "baseline");
+  private final static MethodHandle _FH_baseline = _FC_baseline.dynamicInvoker();
+  private final static CallSite _FC_format = TypeSystemImpl.createCallSite(Line.class, "format");
+  private final static MethodHandle _FH_format = _FC_format.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Line() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Line(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Line(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Line(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: baseline
+
+  /** getter for baseline - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getBaseline() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_baseline));
+  }
+    
+  /** setter for baseline - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setBaseline(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_baseline), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: format
+
+  /** getter for format - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public Format getFormat() { 
+    return (Format)(_getFeatureValueNc(wrapGetIntCatchException(_FH_format)));
+  }
+    
+  /** setter for format - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setFormat(Format v) {
+    _setFeatureValueNcWj(wrapGetIntCatchException(_FH_format), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Page.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Page.java
@@ -1,0 +1,278 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div;
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Page extends Div {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Page";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Page.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_index = "index";
+  public final static String _FeatName_pageNumber = "pageNumber";
+  public final static String _FeatName_uri = "uri";
+  public final static String _FeatName_width = "width";
+  public final static String _FeatName_height = "height";
+  public final static String _FeatName_resolution = "resolution";
+  public final static String _FeatName_rotation = "rotation";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_index = TypeSystemImpl.createCallSite(Page.class, "index");
+  private final static MethodHandle _FH_index = _FC_index.dynamicInvoker();
+  private final static CallSite _FC_pageNumber = TypeSystemImpl.createCallSite(Page.class, "pageNumber");
+  private final static MethodHandle _FH_pageNumber = _FC_pageNumber.dynamicInvoker();
+  private final static CallSite _FC_uri = TypeSystemImpl.createCallSite(Page.class, "uri");
+  private final static MethodHandle _FH_uri = _FC_uri.dynamicInvoker();
+  private final static CallSite _FC_width = TypeSystemImpl.createCallSite(Page.class, "width");
+  private final static MethodHandle _FH_width = _FC_width.dynamicInvoker();
+  private final static CallSite _FC_height = TypeSystemImpl.createCallSite(Page.class, "height");
+  private final static MethodHandle _FH_height = _FC_height.dynamicInvoker();
+  private final static CallSite _FC_resolution = TypeSystemImpl.createCallSite(Page.class, "resolution");
+  private final static MethodHandle _FH_resolution = _FC_resolution.dynamicInvoker();
+  private final static CallSite _FC_rotation = TypeSystemImpl.createCallSite(Page.class, "rotation");
+  private final static MethodHandle _FH_rotation = _FC_rotation.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Page() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Page(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Page(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Page(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: index
+
+  /** getter for index - gets The page index, i.e. a running number assigned during the processing.
+                        Usually denoted in the file name as the first part, e.g. "1" for "01_123456789.xml"
+   * @generated
+   * @return value of the feature 
+   */
+  public int getIndex() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_index));
+  }
+    
+  /** setter for index - sets The page index, i.e. a running number assigned during the processing.
+                        Usually denoted in the file name as the first part, e.g. "1" for "01_123456789.xml" 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setIndex(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_index), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: pageNumber
+
+  /** getter for pageNumber - gets The page number *as a String* as cover pages etc. are commonly numbered using roman numbers.
+   * @generated
+   * @return value of the feature 
+   */
+  public String getPageNumber() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_pageNumber));
+  }
+    
+  /** setter for pageNumber - sets The page number *as a String* as cover pages etc. are commonly numbered using roman numbers. 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setPageNumber(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_pageNumber), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: uri
+
+  /** getter for uri - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getUri() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_uri));
+  }
+    
+  /** setter for uri - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setUri(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_uri), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: width
+
+  /** getter for width - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getWidth() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_width));
+  }
+    
+  /** setter for width - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setWidth(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_width), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: height
+
+  /** getter for height - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getHeight() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_height));
+  }
+    
+  /** setter for height - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setHeight(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_height), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: resolution
+
+  /** getter for resolution - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getResolution() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_resolution));
+  }
+    
+  /** setter for resolution - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setResolution(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_resolution), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: rotation
+
+  /** getter for rotation - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getRotation() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_rotation));
+  }
+    
+  /** setter for rotation - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setRotation(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_rotation), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Paragraph.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Paragraph.java
@@ -1,0 +1,227 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Paragraph extends de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Paragraph";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Paragraph.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_leftIndent = "leftIndent";
+  public final static String _FeatName_rightIndent = "rightIndent";
+  public final static String _FeatName_startIndent = "startIndent";
+  public final static String _FeatName_lineSpacing = "lineSpacing";
+  public final static String _FeatName_alignment = "alignment";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_leftIndent = TypeSystemImpl.createCallSite(Paragraph.class, "leftIndent");
+  private final static MethodHandle _FH_leftIndent = _FC_leftIndent.dynamicInvoker();
+  private final static CallSite _FC_rightIndent = TypeSystemImpl.createCallSite(Paragraph.class, "rightIndent");
+  private final static MethodHandle _FH_rightIndent = _FC_rightIndent.dynamicInvoker();
+  private final static CallSite _FC_startIndent = TypeSystemImpl.createCallSite(Paragraph.class, "startIndent");
+  private final static MethodHandle _FH_startIndent = _FC_startIndent.dynamicInvoker();
+  private final static CallSite _FC_lineSpacing = TypeSystemImpl.createCallSite(Paragraph.class, "lineSpacing");
+  private final static MethodHandle _FH_lineSpacing = _FC_lineSpacing.dynamicInvoker();
+  private final static CallSite _FC_alignment = TypeSystemImpl.createCallSite(Paragraph.class, "alignment");
+  private final static MethodHandle _FH_alignment = _FC_alignment.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Paragraph() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Paragraph(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Paragraph(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Paragraph(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: leftIndent
+
+  /** getter for leftIndent - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getLeftIndent() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_leftIndent));
+  }
+    
+  /** setter for leftIndent - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setLeftIndent(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_leftIndent), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: rightIndent
+
+  /** getter for rightIndent - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getRightIndent() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_rightIndent));
+  }
+    
+  /** setter for rightIndent - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setRightIndent(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_rightIndent), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: startIndent
+
+  /** getter for startIndent - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getStartIndent() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_startIndent));
+  }
+    
+  /** setter for startIndent - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setStartIndent(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_startIndent), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: lineSpacing
+
+  /** getter for lineSpacing - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getLineSpacing() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_lineSpacing));
+  }
+    
+  /** setter for lineSpacing - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setLineSpacing(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_lineSpacing), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: alignment
+
+  /** getter for alignment - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getAlignment() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_alignment));
+  }
+    
+  /** setter for alignment - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setAlignment(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_alignment), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/StructuralElement.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/StructuralElement.java
@@ -1,0 +1,204 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div;
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class StructuralElement extends Div {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.StructuralElement";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(StructuralElement.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_top = "top";
+  public final static String _FeatName_bottom = "bottom";
+  public final static String _FeatName_left = "left";
+  public final static String _FeatName_right = "right";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_top = TypeSystemImpl.createCallSite(StructuralElement.class, "top");
+  private final static MethodHandle _FH_top = _FC_top.dynamicInvoker();
+  private final static CallSite _FC_bottom = TypeSystemImpl.createCallSite(StructuralElement.class, "bottom");
+  private final static MethodHandle _FH_bottom = _FC_bottom.dynamicInvoker();
+  private final static CallSite _FC_left = TypeSystemImpl.createCallSite(StructuralElement.class, "left");
+  private final static MethodHandle _FH_left = _FC_left.dynamicInvoker();
+  private final static CallSite _FC_right = TypeSystemImpl.createCallSite(StructuralElement.class, "right");
+  private final static MethodHandle _FH_right = _FC_right.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected StructuralElement() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public StructuralElement(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public StructuralElement(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public StructuralElement(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: top
+
+  /** getter for top - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getTop() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_top));
+  }
+    
+  /** setter for top - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setTop(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_top), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: bottom
+
+  /** getter for bottom - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getBottom() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_bottom));
+  }
+    
+  /** setter for bottom - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setBottom(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_bottom), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: left
+
+  /** getter for left - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getLeft() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_left));
+  }
+    
+  /** setter for left - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setLeft(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_left), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: right
+
+  /** getter for right - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getRight() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_right));
+  }
+    
+  /** setter for right - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setRight(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_right), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Token.java
+++ b/src/main/java/org/texttechnologylab/annotation/ocr/abbyy/Token.java
@@ -1,0 +1,300 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:59:23 CEST 2025 */
+
+package org.texttechnologylab.annotation.ocr.abbyy;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import org.apache.uima.jcas.cas.StringList;
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:59:23 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Token extends de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.ocr.abbyy.Token";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Token.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_subTokenList = "subTokenList";
+  public final static String _FeatName_isWordFromDictionary = "isWordFromDictionary";
+  public final static String _FeatName_isWordNormal = "isWordNormal";
+  public final static String _FeatName_isWordNumeric = "isWordNumeric";
+  public final static String _FeatName_containsHyphen = "containsHyphen";
+  public final static String _FeatName_suspiciousChars = "suspiciousChars";
+  public final static String _FeatName_minCharConfidence = "minCharConfidence";
+  public final static String _FeatName_meanCharConfidence = "meanCharConfidence";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_subTokenList = TypeSystemImpl.createCallSite(Token.class, "subTokenList");
+  private final static MethodHandle _FH_subTokenList = _FC_subTokenList.dynamicInvoker();
+  private final static CallSite _FC_isWordFromDictionary = TypeSystemImpl.createCallSite(Token.class, "isWordFromDictionary");
+  private final static MethodHandle _FH_isWordFromDictionary = _FC_isWordFromDictionary.dynamicInvoker();
+  private final static CallSite _FC_isWordNormal = TypeSystemImpl.createCallSite(Token.class, "isWordNormal");
+  private final static MethodHandle _FH_isWordNormal = _FC_isWordNormal.dynamicInvoker();
+  private final static CallSite _FC_isWordNumeric = TypeSystemImpl.createCallSite(Token.class, "isWordNumeric");
+  private final static MethodHandle _FH_isWordNumeric = _FC_isWordNumeric.dynamicInvoker();
+  private final static CallSite _FC_containsHyphen = TypeSystemImpl.createCallSite(Token.class, "containsHyphen");
+  private final static MethodHandle _FH_containsHyphen = _FC_containsHyphen.dynamicInvoker();
+  private final static CallSite _FC_suspiciousChars = TypeSystemImpl.createCallSite(Token.class, "suspiciousChars");
+  private final static MethodHandle _FH_suspiciousChars = _FC_suspiciousChars.dynamicInvoker();
+  private final static CallSite _FC_minCharConfidence = TypeSystemImpl.createCallSite(Token.class, "minCharConfidence");
+  private final static MethodHandle _FH_minCharConfidence = _FC_minCharConfidence.dynamicInvoker();
+  private final static CallSite _FC_meanCharConfidence = TypeSystemImpl.createCallSite(Token.class, "meanCharConfidence");
+  private final static MethodHandle _FH_meanCharConfidence = _FC_meanCharConfidence.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Token() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Token(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Token(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Token(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: subTokenList
+
+  /** getter for subTokenList - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public StringList getSubTokenList() { 
+    return (StringList)(_getFeatureValueNc(wrapGetIntCatchException(_FH_subTokenList)));
+  }
+    
+  /** setter for subTokenList - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setSubTokenList(StringList v) {
+    _setFeatureValueNcWj(wrapGetIntCatchException(_FH_subTokenList), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: isWordFromDictionary
+
+  /** getter for isWordFromDictionary - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getIsWordFromDictionary() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_isWordFromDictionary));
+  }
+    
+  /** setter for isWordFromDictionary - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setIsWordFromDictionary(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_isWordFromDictionary), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: isWordNormal
+
+  /** getter for isWordNormal - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getIsWordNormal() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_isWordNormal));
+  }
+    
+  /** setter for isWordNormal - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setIsWordNormal(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_isWordNormal), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: isWordNumeric
+
+  /** getter for isWordNumeric - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getIsWordNumeric() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_isWordNumeric));
+  }
+    
+  /** setter for isWordNumeric - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setIsWordNumeric(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_isWordNumeric), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: containsHyphen
+
+  /** getter for containsHyphen - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public boolean getContainsHyphen() { 
+    return _getBooleanValueNc(wrapGetIntCatchException(_FH_containsHyphen));
+  }
+    
+  /** setter for containsHyphen - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setContainsHyphen(boolean v) {
+    _setBooleanValueNfc(wrapGetIntCatchException(_FH_containsHyphen), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: suspiciousChars
+
+  /** getter for suspiciousChars - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public int getSuspiciousChars() { 
+    return _getIntValueNc(wrapGetIntCatchException(_FH_suspiciousChars));
+  }
+    
+  /** setter for suspiciousChars - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setSuspiciousChars(int v) {
+    _setIntValueNfc(wrapGetIntCatchException(_FH_suspiciousChars), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: minCharConfidence
+
+  /** getter for minCharConfidence - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public short getMinCharConfidence() { 
+    return _getShortValueNc(wrapGetIntCatchException(_FH_minCharConfidence));
+  }
+    
+  /** setter for minCharConfidence - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setMinCharConfidence(short v) {
+    _setShortValueNfc(wrapGetIntCatchException(_FH_minCharConfidence), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: meanCharConfidence
+
+  /** getter for meanCharConfidence - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public float getMeanCharConfidence() { 
+    return _getFloatValueNc(wrapGetIntCatchException(_FH_meanCharConfidence));
+  }
+    
+  /** setter for meanCharConfidence - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setMeanCharConfidence(float v) {
+    _setFloatValueNfc(wrapGetIntCatchException(_FH_meanCharConfidence), v);
+  }    
+    
+  }
+
+    

--- a/src/main/resources/desc/type/AbbyyFineReaderTypeSystem.xml
+++ b/src/main/resources/desc/type/AbbyyFineReaderTypeSystem.xml
@@ -55,12 +55,6 @@
                     <description/>
                     <rangeTypeName>uima.cas.String</rangeTypeName>
                 </featureDescription>
-
-                <featureDescription>
-                    <name>valid</name>
-                    <description/>
-                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
-                </featureDescription>
             </features>
         </typeDescription>
         <typeDescription>
@@ -88,7 +82,10 @@
                     <string>SeparatorsBox</string>
                 </value>
                 <value>
-                    <string>INVALID</string>
+                    <string>Checkmark</string>
+                </value>
+                <value>
+                    <string>GroupCheckmark</string>
                 </value>
             </allowedValues>
         </typeDescription>
@@ -275,6 +272,18 @@
                     <description/>
                     <rangeTypeName>uima.cas.Integer</rangeTypeName>
                 </featureDescription>
+
+                <featureDescription>
+                    <name>minCharConfidence</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Short</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>meanCharConfidence</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Float</rangeTypeName>
+                </featureDescription>
             </features>
         </typeDescription>
         <typeDescription>
@@ -317,7 +326,22 @@
                     <description/>
                     <rangeTypeName>uima.cas.Integer</rangeTypeName>
                 </featureDescription>
+                <featureDescription>
+                    <name>rotation</name>
+                    <description/>
+                    <rangeTypeName>org.texttechnologylab.annotation.ocr.abbyy.Orientation</rangeTypeName>
+                </featureDescription>
             </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Orientation</name>
+            <supertypeName>uima.cas.String</supertypeName>
+            <allowedValues>
+                <value><string>Normal</string></value>
+                <value><string>RotatedClockwise</string></value>
+                <value><string>RotatedUpsidedown</string></value>
+                <value><string>RotatedCounterclockwise</string></value>
+            </allowedValues>
         </typeDescription>
         <typeDescription>
             <name>org.texttechnologylab.annotation.ocr.abbyy.Document</name>

--- a/src/main/resources/desc/type/AbbyyFineReaderTypeSystem.xml
+++ b/src/main/resources/desc/type/AbbyyFineReaderTypeSystem.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <name>AbbyyFineReader</name>
+    <description>
+        Types for documents constructed from the ABBYY FineReader OCR-engine output.
+    </description>
+    <version>1.0</version>
+    <vendor/>
+    <types>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.StructuralElement</name>
+            <description/>
+            <supertypeName>de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>top</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>bottom</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>left</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>right</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Block</name>
+            <description/>
+            <supertypeName>org.texttechnologylab.annotation.ocr.abbyy.StructuralElement</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>blockType</name>
+                    <description/>
+                    <rangeTypeName>org.texttechnologylab.annotation.ocr.abbyy.BlockType</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>blockName</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>valid</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.BlockType</name>
+            <description/>
+            <supertypeName>uima.cas.String</supertypeName>
+
+            <allowedValues>
+                <value>
+                    <string>Text</string>
+                </value>
+                <value>
+                    <string>Table</string>
+                </value>
+                <value>
+                    <string>Picture</string>
+                </value>
+                <value>
+                    <string>Barcode</string>
+                </value>
+                <value>
+                    <string>Separator</string>
+                </value>
+                <value>
+                    <string>SeparatorsBox</string>
+                </value>
+                <value>
+                    <string>INVALID</string>
+                </value>
+            </allowedValues>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Line</name>
+            <description/>
+            <supertypeName>org.texttechnologylab.annotation.ocr.abbyy.StructuralElement</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>baseline</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>format</name>
+                    <description/>
+                    <rangeTypeName>org.texttechnologylab.annotation.ocr.abbyy.Format</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Paragraph</name>
+            <description/>
+            <supertypeName>de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>leftIndent</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>rightIndent</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>startIndent</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>lineSpacing</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>alignment</name>
+                    <description/>
+                    <rangeTypeName>org.texttechnologylab.annotation.ocr.abbyy.ParagraphAlignment</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.ParagraphAlignment</name>
+            <supertypeName>uima.cas.String</supertypeName>
+            <allowedValues>
+                <value>
+                    <string>Left</string>
+                </value>
+                <value>
+                    <string>Center</string>
+                </value>
+                <value>
+                    <string>Right</string>
+                </value>
+                <value>
+                    <string>Justified</string>
+                </value>
+            </allowedValues>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Format</name>
+            <description/>
+            <supertypeName>uima.tcas.Annotation</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>lang</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>ff</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>fs</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Float</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>bold</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>italic</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>subscript</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>superscript</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>smallcaps</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>underline</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>strikeout</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Token</name>
+            <description/>
+            <supertypeName>de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>subTokenList</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.StringList</rangeTypeName>
+                    <multipleReferencesAllowed>false</multipleReferencesAllowed>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>isWordFromDictionary</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>isWordNormal</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>isWordNumeric</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>containsHyphen</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>suspiciousChars</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Page</name>
+            <description/>
+            <supertypeName>de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>index</name>
+                    <description>
+                        The page index, i.e. a running number assigned during the processing.
+                        Usually denoted in the file name as the first part, e.g. "1" for "01_123456789.xml"
+                    </description>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>pageNumber</name>
+                    <description>
+                        The page number *as a String* as cover pages etc. are commonly numbered using roman numbers.
+                    </description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>uri</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>width</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>height</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>resolution</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.ocr.abbyy.Document</name>
+            <description/>
+            <supertypeName>de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Document</supertypeName>
+
+            <features>
+                <featureDescription>
+                    <name>documentName</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>version</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>producer</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>pagesCount</name>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>mainLanguage</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>languages</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+    </types>
+</typeSystemDescription>


### PR DESCRIPTION
This PR adds a new type system for ABBYY FineReader OCR elements.
It is designed in tandem to the new reader implementation in DUUI in [PR#120](https://github.com/texttechnologylab/DockerUnifiedUIMAInterface/pull/120).

The new type system is located under the path `org.texttechnologylab.annotation.ocr.abbyy.*`.
All elements are designed to mirror the ABBYY FineReader XML schema, now in version 10, with some additional metadata where reasonable.
In comparison to the old one, this new version makes better use of `<allowedValues>` and proper super-types from the DKPro type system.


*Version number `3.0.6-alpha` is just for debugging*