### PR TITLE
New Type System for Taxonomic Names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.texttechnologylab.annotation</groupId>
     <artifactId>typesystem</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6-alpha</version>
 
     <licenses>
         <license>
@@ -103,15 +103,15 @@
                         src/main/java/
                     </outputDirectory>
                 </configuration>
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        &lt;!&ndash;call it in the generate-source phase &ndash;&gt;-->
-<!--                        <phase>generate-sources</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>generate</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
+                <executions>
+                    <execution>
+                        <!--call it in the generate-source phase -->
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/main/java/org/texttechnologylab/annotation/biofid/Taxon.java
+++ b/src/main/java/org/texttechnologylab/annotation/biofid/Taxon.java
@@ -1,0 +1,132 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:58:11 CEST 2025 */
+
+package org.texttechnologylab.annotation.biofid;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:58:11 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Taxon extends NamedEntity {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.biofid.Taxon";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Taxon.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_value = "value";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_value = TypeSystemImpl.createCallSite(Taxon.class, "value");
+  private final static MethodHandle _FH_value = _FC_value.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Taxon() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Taxon(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Taxon(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Taxon(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: value
+
+  /** getter for value - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getValue() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_value));
+  }
+    
+  /** setter for value - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setValue(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_value), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/biofid/gazetteer/Taxon.java
+++ b/src/main/java/org/texttechnologylab/annotation/biofid/gazetteer/Taxon.java
@@ -1,0 +1,104 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:58:11 CEST 2025 */
+
+package org.texttechnologylab.annotation.biofid.gazetteer;
+ 
+
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:58:11 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Taxon extends org.texttechnologylab.annotation.biofid.Taxon {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.biofid.gazetteer.Taxon";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Taxon.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+
+
+  /* Feature Adjusted Offsets */
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Taxon() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Taxon(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Taxon(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Taxon(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+}
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/biofid/gnfinder/Taxon.java
+++ b/src/main/java/org/texttechnologylab/annotation/biofid/gnfinder/Taxon.java
@@ -1,0 +1,211 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:58:11 CEST 2025 */
+
+package org.texttechnologylab.annotation.biofid.gnfinder;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:58:11 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class Taxon extends org.texttechnologylab.annotation.biofid.Taxon {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.biofid.gnfinder.Taxon";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Taxon.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_Version = "Version";
+  public final static String _FeatName_Language = "Language";
+  public final static String _FeatName_Cardinality = "Cardinality";
+  public final static String _FeatName_OddsLog10 = "OddsLog10";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_Version = TypeSystemImpl.createCallSite(Taxon.class, "Version");
+  private final static MethodHandle _FH_Version = _FC_Version.dynamicInvoker();
+  private final static CallSite _FC_Language = TypeSystemImpl.createCallSite(Taxon.class, "Language");
+  private final static MethodHandle _FH_Language = _FC_Language.dynamicInvoker();
+  private final static CallSite _FC_Cardinality = TypeSystemImpl.createCallSite(Taxon.class, "Cardinality");
+  private final static MethodHandle _FH_Cardinality = _FC_Cardinality.dynamicInvoker();
+  private final static CallSite _FC_OddsLog10 = TypeSystemImpl.createCallSite(Taxon.class, "OddsLog10");
+  private final static MethodHandle _FH_OddsLog10 = _FC_OddsLog10.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected Taxon() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public Taxon(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Taxon(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Taxon(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: Version
+
+  /** getter for Version - gets gnfinder version.
+   * @generated
+   * @return value of the feature 
+   */
+  public String getVersion() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_Version));
+  }
+    
+  /** setter for Version - sets gnfinder version. 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setVersion(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_Version), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: Language
+
+  /** getter for Language - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getLanguage() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_Language));
+  }
+    
+  /** setter for Language - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setLanguage(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_Language), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: Cardinality
+
+  /** getter for Cardinality - gets Cardinality depicts number of elements in a name.
+                        0 - Cannot determine cardinality,
+                        1 - Uninomial,
+                        2 - Binomial,
+                        3 - Trinomial.
+   * @generated
+   * @return value of the feature 
+   */
+  public short getCardinality() { 
+    return _getShortValueNc(wrapGetIntCatchException(_FH_Cardinality));
+  }
+    
+  /** setter for Cardinality - sets Cardinality depicts number of elements in a name.
+                        0 - Cannot determine cardinality,
+                        1 - Uninomial,
+                        2 - Binomial,
+                        3 - Trinomial. 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setCardinality(short v) {
+    _setShortValueNfc(wrapGetIntCatchException(_FH_Cardinality), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: OddsLog10
+
+  /** getter for OddsLog10 - gets Log10 of the odds (probability) that name detection was correct.
+   * @generated
+   * @return value of the feature 
+   */
+  public float getOddsLog10() { 
+    return _getFloatValueNc(wrapGetIntCatchException(_FH_OddsLog10));
+  }
+    
+  /** setter for OddsLog10 - sets Log10 of the odds (probability) that name detection was correct. 
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setOddsLog10(float v) {
+    _setFloatValueNfc(wrapGetIntCatchException(_FH_OddsLog10), v);
+  }    
+    
+  }
+
+    

--- a/src/main/java/org/texttechnologylab/annotation/biofid/gnfinder/VerifiedTaxon.java
+++ b/src/main/java/org/texttechnologylab/annotation/biofid/gnfinder/VerifiedTaxon.java
@@ -1,0 +1,276 @@
+
+
+   
+/* Apache UIMA v3 - First created by JCasGen Tue Apr 15 18:58:11 CEST 2025 */
+
+package org.texttechnologylab.annotation.biofid.gnfinder;
+ 
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.impl.TypeSystemImpl;
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+
+
+import org.texttechnologylab.annotation.biofid.Taxon;
+
+
+/** 
+ * Updated by JCasGen Tue Apr 15 18:58:11 CEST 2025
+ * XML source: /nvme/projects/TTLab/UIMATypeSystem/target/jcasgen/typesystem.xml
+ * @generated */
+public class VerifiedTaxon extends Taxon {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.texttechnologylab.annotation.biofid.gnfinder.VerifiedTaxon";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(VerifiedTaxon.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+  public final static String _FeatName_Id = "Id";
+  public final static String _FeatName_MatchedCanonical = "MatchedCanonical";
+  public final static String _FeatName_CurrentCanonical = "CurrentCanonical";
+  public final static String _FeatName_VerifMatchType = "VerifMatchType";
+  public final static String _FeatName_VerifSortScore = "VerifSortScore";
+  public final static String _FeatName_VerifEditDistance = "VerifEditDistance";
+  public final static String _FeatName_VerifMatchedName = "VerifMatchedName";
+
+
+  /* Feature Adjusted Offsets */
+  private final static CallSite _FC_Id = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "Id");
+  private final static MethodHandle _FH_Id = _FC_Id.dynamicInvoker();
+  private final static CallSite _FC_MatchedCanonical = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "MatchedCanonical");
+  private final static MethodHandle _FH_MatchedCanonical = _FC_MatchedCanonical.dynamicInvoker();
+  private final static CallSite _FC_CurrentCanonical = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "CurrentCanonical");
+  private final static MethodHandle _FH_CurrentCanonical = _FC_CurrentCanonical.dynamicInvoker();
+  private final static CallSite _FC_VerifMatchType = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "VerifMatchType");
+  private final static MethodHandle _FH_VerifMatchType = _FC_VerifMatchType.dynamicInvoker();
+  private final static CallSite _FC_VerifSortScore = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "VerifSortScore");
+  private final static MethodHandle _FH_VerifSortScore = _FC_VerifSortScore.dynamicInvoker();
+  private final static CallSite _FC_VerifEditDistance = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "VerifEditDistance");
+  private final static MethodHandle _FH_VerifEditDistance = _FC_VerifEditDistance.dynamicInvoker();
+  private final static CallSite _FC_VerifMatchedName = TypeSystemImpl.createCallSite(VerifiedTaxon.class, "VerifMatchedName");
+  private final static MethodHandle _FH_VerifMatchedName = _FC_VerifMatchedName.dynamicInvoker();
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected VerifiedTaxon() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public VerifiedTaxon(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public VerifiedTaxon(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public VerifiedTaxon(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: Id
+
+  /** getter for Id - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getId() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_Id));
+  }
+    
+  /** setter for Id - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setId(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_Id), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: MatchedCanonical
+
+  /** getter for MatchedCanonical - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getMatchedCanonical() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_MatchedCanonical));
+  }
+    
+  /** setter for MatchedCanonical - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setMatchedCanonical(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_MatchedCanonical), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: CurrentCanonical
+
+  /** getter for CurrentCanonical - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getCurrentCanonical() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_CurrentCanonical));
+  }
+    
+  /** setter for CurrentCanonical - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setCurrentCanonical(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_CurrentCanonical), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: VerifMatchType
+
+  /** getter for VerifMatchType - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getVerifMatchType() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_VerifMatchType));
+  }
+    
+  /** setter for VerifMatchType - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setVerifMatchType(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_VerifMatchType), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: VerifSortScore
+
+  /** getter for VerifSortScore - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public float getVerifSortScore() { 
+    return _getFloatValueNc(wrapGetIntCatchException(_FH_VerifSortScore));
+  }
+    
+  /** setter for VerifSortScore - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setVerifSortScore(float v) {
+    _setFloatValueNfc(wrapGetIntCatchException(_FH_VerifSortScore), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: VerifEditDistance
+
+  /** getter for VerifEditDistance - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public short getVerifEditDistance() { 
+    return _getShortValueNc(wrapGetIntCatchException(_FH_VerifEditDistance));
+  }
+    
+  /** setter for VerifEditDistance - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setVerifEditDistance(short v) {
+    _setShortValueNfc(wrapGetIntCatchException(_FH_VerifEditDistance), v);
+  }    
+    
+   
+    
+  //*--------------*
+  //* Feature: VerifMatchedName
+
+  /** getter for VerifMatchedName - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getVerifMatchedName() { 
+    return _getStringValueNc(wrapGetIntCatchException(_FH_VerifMatchedName));
+  }
+    
+  /** setter for VerifMatchedName - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setVerifMatchedName(String v) {
+    _setStringValueNfc(wrapGetIntCatchException(_FH_VerifMatchedName), v);
+  }    
+    
+  }
+
+    

--- a/src/main/resources/desc/type/BIOfidTypeSystem.xml
+++ b/src/main/resources/desc/type/BIOfidTypeSystem.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <name>GeoNamesTypeSystem</name>
+    <description/>
+    <version>1.0</version>
+    <vendor/>
+    <types>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.biofid.Taxon</name>
+            <description/>
+            <supertypeName>de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>value</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.biofid.gnfinder.Taxon</name>
+            <description></description>
+            <supertypeName>org.texttechnologylab.annotation.biofid.Taxon</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>Version</name>
+                    <description>gnfinder version.</description>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>Language</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>Cardinality</name>
+                    <description>
+                        Cardinality depicts number of elements in a name.
+                        0 - Cannot determine cardinality,
+                        1 - Uninomial,
+                        2 - Binomial,
+                        3 - Trinomial.
+                    </description>
+                    <rangeTypeName>uima.cas.Short</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>OddsLog10</name>
+                    <description>Log10 of the odds (probability) that name detection was correct.</description>
+                    <rangeTypeName>uima.cas.Float</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.biofid.gnfinder.VerifiedTaxon</name>
+            <description/>
+            <supertypeName>org.texttechnologylab.annotation.biofid.Taxon</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>Id</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>MatchedCanonical</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>CurrentCanonical</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>VerifMatchType</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>VerifSortScore</name>
+                    <rangeTypeName>uima.cas.Float</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>VerifEditDistance</name>
+                    <rangeTypeName>uima.cas.Short</rangeTypeName>
+                </featureDescription>
+                <featureDescription>
+                    <name>VerifMatchedName</name>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+            </features>
+        </typeDescription>
+        <typeDescription>
+            <name>org.texttechnologylab.annotation.biofid.gazetteer.Taxon</name>
+            <description/>
+            <supertypeName>org.texttechnologylab.annotation.biofid.Taxon</supertypeName>
+        </typeDescription>
+    </types>
+</typeSystemDescription>


### PR DESCRIPTION
This new type system for the BIOfid project aims to decouple the existing Taxon types from the TTLab NER types in favor of (just) the DKPro NER type and is designed with first-class support for UCE.

It is still a WIP but this first iteration adds a Taxon sub-type for the `gnfinder` with plans to add more tool-dependent variants that can store tool-dependent values/parameters.